### PR TITLE
Added changes that were tested in the last DWF run for the taking_dar…

### DIFF
--- a/src/huntsman/pocs/observatory.py
+++ b/src/huntsman/pocs/observatory.py
@@ -8,7 +8,7 @@ from astropy import stats
 from astropy import units as u
 from astropy.io import fits
 
-from panoptes.utils import error, altaz_to_radec, listify
+from panoptes.utils import error, altaz_to_radec, listify, get_quantity_value
 from panoptes.utils.library import load_module
 from panoptes.utils.time import current_time, flatten_time, wait_for_events
 
@@ -267,28 +267,32 @@ class HuntsmanObservatory(Observatory):
 
         self.logger.info('Finished flat-fielding.')
 
-    def take_dark_fields(self,
-                         exptimes,
-                         sleep=10,
+    def take_dark_images(self,
+                         exptimes=None,
                          camera_names=None,
                          n_darks=10,
                          imtype='dark',
+                         set_from_config=False,
                          *args, **kwargs
                          ):
         """Take n_darks for each exposure time specified,
            for each camera.
 
         Args:
-            exptimes (list): List of exposure times for darks
-            sleep (float, optional): Time in seconds to sleep between dark sequences.
+            exptimes (list, optional): List of exposure times for darks
             camera_names (list, optional): List of cameras to use for darks
             n_darks (int or list, optional): if int, the same number of darks will be taken
                 for each exptime. If list, the len has to be the same than len(exptimes), where each
                 element is the number of darks we want for the corresponding exptime, e.g.:
-                take_dark_fields(exptimes=[1*u.s, 60*u.s, 15*u.s], n_darks=[30, 10, 20])
+                take_dark_images(exptimes=[1*u.s, 60*u.s, 15*u.s], n_darks=[30, 10, 20])
                 will take 30x1s, 10x60s, and 20x15s darks
+            set_from_config (bool, optional): flag to set exptimes and n_darks directly
+                from config file.
             imtype (str, optional): type of image
         """
+
+        if exptimes is None:
+            exptimes = list()
 
         if camera_names is None:
             cameras_list = self.cameras
@@ -297,51 +301,66 @@ class HuntsmanObservatory(Observatory):
 
         self.logger.debug(f'Using cameras {cameras_list}')
 
-        image_dir = self.get_config('directories.images')
+        filterwheel_events = dict()
 
-        self.logger.debug(f"Taking {n_darks} dark exposures with exposure times: {exptimes}")
+        self.logger.debug(f'Moving all camera filterwheels to blank filter')
+
+        # Move all the camera filterwheels to the blank position.
+        for camera in cameras_list.values():
+            if camera.filterwheel.current_filter != 'blank':
+                filterwheel_event = camera.filterwheel.move_to_dark_position()
+                filterwheel_events[camera] = filterwheel_event
+        self.logger.debug('Waiting for all the filterwheels to move to the dark position')
+        wait_for_events(list(filterwheel_events.values()))
 
         # List to check that the final number of darks is equal to the number
         # of cameras times the number of exptimes times n_darks.
-        darks_filenames = []
+        darks_filenames = list()
 
         exptimes = listify(exptimes)
 
         if not isinstance(n_darks, list):
             n_darks = listify(n_darks) * len(exptimes)
 
+        if set_from_config:
+            dark_config = self.get_config('calibs.dark', default=dict())
+            exptimes = dark_config['exposure_time']
+            n_darks = dark_config['n_darks']
+
         # Loop over cameras.
+        if len(exptimes) == 0:
+            raise error.PanError('No exposure times were provided. No dark images were taken.')
+
+        self.logger.info(f'Going to take {n_darks} darks for these exposure times {exptimes}')
         for exptime, num_darks in zip(exptimes, n_darks):
 
             start_time = current_time()
 
             with suppress(AttributeError):
-                exptime = exptime.to_value(u.second)
+                exptime = get_quantity_value(exptime, u.second)
 
+            # Create dark observation
             dark_obs = self._create_dark_observation(exptime)
 
             # Loop over exposure times for each camera.
             for num in range(num_darks):
 
-                self.logger.debug(f'Darks sequence #{num} of exposure time {exptime}s')
+                self.logger.debug(f'Taking dark {num + 1} of {num_darks} with exptime={exptime} s.')
 
                 camera_events = dict()
 
                 # Take a given number of exposures for each exposure time.
                 for camera in cameras_list.values():
-                    # Create dark observation
+
+                    # Set header
                     fits_headers = self.get_standard_headers(observation=dark_obs)
                     # Common start time for cameras
                     fits_headers['start_time'] = flatten_time(start_time)
 
                     # Create filename
-                    path = os.path.join(image_dir,
-                                        'darks',
-                                        camera.uid,
-                                        dark_obs.seq_time)
+                    path = os.path.join(dark_obs.directory, camera.uid, dark_obs.seq_time)
 
-                    filename = os.path.join(
-                        path, f'{imtype}_{num:02d}.{camera.file_extension}')
+                    filename = os.path.join(path, f'{imtype}_{num:02d}.{camera.file_extension}')
 
                     # Take picture and get event
                     camera_event = camera.take_observation(
@@ -365,9 +384,8 @@ class HuntsmanObservatory(Observatory):
                     self.logger.debug(camera_events)
 
                 # Block until done exposing on all cameras
-                while not all([info['event'].is_set() for info in camera_events.values()]):
-                    self.logger.debug('Waiting for dark-field images...')
-                    time.sleep(sleep)
+                self.logger.debug('Waiting for dark images...')
+                wait_for_events(list(info['event'] for info in camera_events.values()))
         self.logger.debug(darks_filenames)
         return darks_filenames
 
@@ -510,8 +528,6 @@ class HuntsmanObservatory(Observatory):
 
         if isinstance(dark_obs, DarkObservation):
             dark_obs.exptime = exptime
-
-        self.logger.debug(f"Dark-field observation: {dark_obs}")
 
         return dark_obs
 

--- a/src/huntsman/pocs/scheduler/dark_observation.py
+++ b/src/huntsman/pocs/scheduler/dark_observation.py
@@ -1,3 +1,4 @@
+import os
 from astropy import units as u
 from contextlib import suppress
 
@@ -7,11 +8,12 @@ from panoptes.utils import listify
 
 
 class DarkObservation(Observation):
-    """ A Dark-field observation
+
+    """ A Dark observation
 
     Dark observations will consist of multiple exposure. As the mount will be
-    parked when using this class, the fields will be centred at the parked
-    position.
+    parked when using this class, the fits image header RA, Dec will be centred
+    at the parked position.
 
     Note:
         For now the new observation must be created like a normal `Observation`,
@@ -27,14 +29,17 @@ class DarkObservation(Observation):
                 `~astropy.coordinates.SkyCoord`.
         """
         # Create the observation
-        dark_field = Field('Dark-Field', position)
-        super().__init__(field=dark_field, *args, **kwargs)
+        dark_image = Field('Dark', position)
+        super().__init__(field=dark_image, *args, **kwargs)
 
         # Set initial list to original values
         self._exptime = listify(self.exptime)
         self._field = listify(self.field)
 
         self.extra_config = kwargs
+
+        # Specify directory root for file storage
+        self._directory = os.path.join(self._image_dir, 'darks')
 
     @property
     def exptime(self):

--- a/src/huntsman/pocs/states/huntsman/taking_darks.py
+++ b/src/huntsman/pocs/states/huntsman/taking_darks.py
@@ -7,10 +7,8 @@ def on_enter(event_data):
 
         pocs.say("It's time to take darks!")
 
-        pocs.status()
-
         # Wait until mount is parked
-        pocs.say("Everything set up for dark fields")
+        pocs.say("Everything set up for darks")
 
         exptimes_list = list()
         for target in pocs.observatory.scheduler.fields_list:
@@ -18,10 +16,12 @@ def on_enter(event_data):
             if exptime not in exptimes_list:
                 exptimes_list.append(exptime)
 
-            if len(exptimes_list) > 0:
-                pocs.say("I'm starting with dark-field exposures")
-                pocs.observatory.take_dark_fields(exptimes_list)
+        pocs.say("I'm starting with dark exposures")
+        pocs.observatory.take_dark_images(exptimes_list)
+
     except Exception as e:
         pocs.logger.warning("Problem encountered while taking darks: {}".format(e))
 
-    pocs.next_state = 'housekeeping'
+    finally:
+        pocs.say("Going to housekeeping state.")
+        pocs.next_state = 'housekeeping'


### PR DESCRIPTION
…ks state (#261)

* Added changes already tested in take_dark_fields and DarkObservation

* Changed self.config to self.get_config according to POCS last version

* Fixed bug in taking_darks state. ALL unit tests pass now. Ready for PR.

* Added else statement when no exposure times are found.

* Added word to pocs message.

* Improved prompt message

* Removed unnecessary pocs.status call.

* Addressed Lee's last comments before merging PR.

* Added import get_quantity_value

* Removed sleep argument and changed [] to None in exptimes

* Edited docstrings in DarkObservation class

* Addressed last comments from Dan and Lee in take_dark_images()