### PR TITLE
Fix bug dome removing .decode() from already decoded string (#308)

### DIFF
--- a/src/huntsman/pocs/dome/musca.py
+++ b/src/huntsman/pocs/dome/musca.py
@@ -240,7 +240,7 @@ class HuntsmanDome(AbstractSerialDome):
         """Read serial bluetooth device musca."""
         if log_message is not None:
             self.logger.info(log_message)
-        lines = self.serial.read()
+        lines = self.serial.ser.readlines()
         time.sleep(self._command_delay)
         return lines
 


### PR DESCRIPTION
* Update fork (#9)

* add functionality (#284)

* mount targets (#285)

Co-authored-by: Lee Spitler <lee.spitler@mq.edu.au>
Co-authored-by: danjampro <danjampro@sky.com>

* Removed decode(). Already decoded by self.serial.read().

* Reverted self.serial.read() to self.serial.ser.readlines()

* Added decode() to string

Co-authored-by: Lee Spitler <lee.spitler@mq.edu.au>
Co-authored-by: danjampro <danjampro@sky.com>